### PR TITLE
chore: add comments to exports in user impl module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ function capitalize(s: string) {
 }
 
 function camelToSnakeCase(s: string) {
-  return s.split(/(?=[A-Z])/).join('_').toLowerCase()
+  return s.split(/(?=[A-Z])/).join("_").toLowerCase();
 }
 
 export function render() {
@@ -97,7 +97,7 @@ export function render() {
     makePublic,
     jsonWrappedRustType,
     capitalize,
-    camelToSnakeCase
+    camelToSnakeCase,
   };
 
   const output = ejs.render(tmpl, ctx);

--- a/template/src/lib.rs.ejs
+++ b/template/src/lib.rs.ejs
@@ -1,10 +1,12 @@
 mod pdk;
-use pdk::*;
 
+use pdk::*;
 use extism_pdk::*;
 
 <% schema.exports.forEach(ex => { -%>
-
+<% if (hasComment(ex)) { -%>
+// <%- formatCommentBlock(ex.description, "// ") %>
+<% } -%>
 pub(crate) fn <%= camelToSnakeCase(ex.name) %>(<%if (ex.input) { %>_input: <%- toRustType(ex.input) %> <% } %>) -> Result<<%if (ex.output) { %> <%- toRustType(ex.output) %> <% } else { %> () <% } %>, Error> {
 	<% if (featureFlags['stub-with-code-samples'] && codeSamples(ex, 'rust').length > 0) { -%>
 		<%- codeSamples(ex, 'rust')[0].source %>


### PR DESCRIPTION
Partially completes #2 

After looking at it more, I think the paths are way simpler to leave in the types, and not that hard for the end-user to remove & add a `use` themselves. There's a few different contexts in which this bindgen would need to check if a `use` statement is needed, and it's a bit complex to abstract, and alternatively super verbose to check around all the edges.