### PR TITLE
fix: improve handling of buffer type in JSON encoded structs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-bindgen": "1.0.0-rc.5",
+        "@dylibso/xtp-bindgen": "1.0.0-rc.7",
         "ejs": "^3.1.10"
       },
       "devDependencies": {
@@ -21,9 +21,10 @@
       }
     },
     "node_modules/@dylibso/xtp-bindgen": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.5.tgz",
-      "integrity": "sha512-F+s0XA5NeS7q6ikWe7Qou8AsLqYJfCQQbFEpgzWsqIh3YoLF7jcEwgc3Df60FbRocitOf/ZRlCxgaqJlAuD73w=="
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.7.tgz",
+      "integrity": "sha512-8nMT8xqsC6FYVT2tS4xB3R+VVYAfiu6AceZLlRjfB2SCE5H6YqgX0INU9ZL9IacvFr+mRjEoQZ6B+G4Y/WR9WQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@dylibso/xtp-bindgen": "1.0.0-rc.5",
+    "@dylibso/xtp-bindgen": "1.0.0-rc.7",
     "ejs": "^3.1.10"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,14 +80,6 @@ function makePublic(s: string) {
   return "pub " + s;
 }
 
-function capitalize(s: string) {
-  return s.charAt(0).toUpperCase() + s.slice(1);
-}
-
-function camelToSnakeCase(s: string) {
-  return s.split(/(?=[A-Z])/).join("_").toLowerCase();
-}
-
 export function render() {
   const tmpl = Host.inputString();
   const ctx = {
@@ -96,8 +88,6 @@ export function render() {
     toRustType,
     makePublic,
     jsonWrappedRustType,
-    capitalize,
-    camelToSnakeCase,
   };
 
   const output = ejs.render(tmpl, ctx);

--- a/template/Cargo.toml.ejs
+++ b/template/Cargo.toml.ejs
@@ -12,3 +12,5 @@ extism-pdk = "1.1.0"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+base64-serde = "0.7"
+base64 = "0.21"

--- a/template/src/pdk.rs.ejs
+++ b/template/src/pdk.rs.ejs
@@ -33,6 +33,9 @@ macro_rules! try_input_json {
     }}
 }
 
+use base64_serde::base64_serde_type;
+
+base64_serde_type!(Base64Standard, base64::engine::general_purpose::STANDARD);
 
 <% schema.exports.forEach(ex => { -%>
 
@@ -74,6 +77,7 @@ pub struct <%- capitalize(schema.name) %> {
 		<% } -%>
     #[serde(rename = "<%- p.name %>")]
     <% if (p.nullable) { %>#[serde(default)]<% } %>
+    <% if (p.type === "buffer") { %> #[serde(with = "Base64Standard")] <% } %>
 		<%- makePublic(camelToSnakeCase(p.name)) %>: <%- p.nullable ? `Option<${toRustType(p)}>` : toRustType(p) %>,
 		<% }) %>
 


### PR DESCRIPTION
- Uses base64 for encoding/decoding `buffer` values in JSON encoded structs, unfortunately `extism_convert::Base64` doesn't work here since it doesn't implement `serde::{Serialize, Deserialize}`
- Updates `xtp-bindgen` so we can use the built-in `camelToSnakeCase` and `capitalize` functions