### PR TITLE
cleanup: add workspace entry to Cargo.toml, derive Debug and Clone for types

### DIFF
--- a/template/Cargo.toml.ejs
+++ b/template/Cargo.toml.ejs
@@ -14,3 +14,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64-serde = "0.7"
 base64 = "0.21"
+
+[workspace]
+members = ["."]

--- a/template/Cargo.toml.ejs
+++ b/template/Cargo.toml.ejs
@@ -16,4 +16,3 @@ base64-serde = "0.7"
 base64 = "0.21"
 
 [workspace]
-members = ["."]

--- a/template/src/pdk.rs.ejs
+++ b/template/src/pdk.rs.ejs
@@ -74,7 +74,7 @@ pub mod types {
     use super::*;
 <% Object.values(schema.schemas).forEach(schema => { %>
     <% if (isEnum(schema)) { %>
-#[derive(Default, serde::Serialize, serde::Deserialize, extism_pdk::FromBytes, extism_pdk::ToBytes)]
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, extism_pdk::FromBytes, extism_pdk::ToBytes)]
 #[encoding(Json)]
 pub enum <%- capitalize(schema.name) %> {
     #[default]
@@ -84,7 +84,7 @@ pub enum <%- capitalize(schema.name) %> {
 		<% }) %>
 }
     <% } else { %>
-#[derive(Default, serde::Serialize, serde::Deserialize, extism_pdk::FromBytes, extism_pdk::ToBytes)]
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, extism_pdk::FromBytes, extism_pdk::ToBytes)]
 #[encoding(Json)]
 pub struct <%- capitalize(schema.name) %> {
     <% schema.properties.forEach(p => { -%>


### PR DESCRIPTION
Closes #19 

- Derives `Debug` and `Clone` for PDK types
- Also adds `workspace` section to Cargo.toml, which should allow plugins to be built in a nested cargo workspace