### PR TITLE
fix shadowed var issue

### DIFF
--- a/template/src/lib.rs.ejs
+++ b/template/src/lib.rs.ejs
@@ -7,7 +7,7 @@ use extism_pdk::*;
 <% if (hasComment(ex)) { -%>
 // <%- formatCommentBlock(ex.description, "// ") %>
 <% } -%>
-pub(crate) fn <%= formatIdentifier(ex.name) %>(<%if (ex.input) { %>_input: <%- toRustType(ex.input) %> <% } %>) -> Result<<%if (ex.output) { %> <%- toRustType(ex.output) %> <% } else { %> () <% } %>, Error> {
+pub(crate) fn <%= formatIdentifier(ex.name) %>(<%if (ex.input) { %>input: <%- toRustType(ex.input) %> <% } %>) -> Result<<%if (ex.output) { %> <%- toRustType(ex.output) %> <% } else { %> () <% } %>, Error> {
 	<% if (featureFlags['stub-with-code-samples'] && codeSamples(ex, 'rust').length > 0) { -%>
 		<%- codeSamples(ex, 'rust')[0].source %>
 	<% } else { -%>


### PR DESCRIPTION
When we use stub-with-code-samples, this should be `input` not `_input`.
